### PR TITLE
Structured output support

### DIFF
--- a/r/R/llm-use.R
+++ b/r/R/llm-use.R
@@ -45,6 +45,7 @@
 llm_use <- function(
     backend = NULL,
     model = NULL,
+    output = "text",
     ...,
     .silent = FALSE,
     .cache = NULL,
@@ -91,6 +92,7 @@ llm_use <- function(
   m_defaults_set(
     backend = backend,
     model = model,
+    output = output,
     .cache = cache,
     ...
   )

--- a/r/R/m-backend-submit.R
+++ b/r/R/m-backend-submit.R
@@ -28,7 +28,7 @@ m_backend_submit.mall_ollama <- function(backend, x, prompt, preview = FALSE) {
     \(x) {
       .args <- c(
         messages = list(map(prompt, \(i) map(i, \(j) glue(j, x = x)))),
-        output = "text",
+        # output = "text",
         m_defaults_args(backend)
       )
       res <- NULL

--- a/r/R/m-backend-submit.R
+++ b/r/R/m-backend-submit.R
@@ -20,8 +20,10 @@ m_backend_submit.mall_ollama <- function(backend, x, prompt, preview = FALSE) {
   if (preview) {
     x <- head(x, 1)
     map_here <- map
-  } else {
+  } else if (identical(m_defaults_args(backend)$output, "text")) {
     map_here <- map_chr
+  } else {
+    map_here <- map
   }
   map_here(
     x,

--- a/r/mall.Rproj
+++ b/r/mall.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 80851bf4-539e-478d-944c-84a2f4c9527b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
This PR provides a minimal implementation of the approach to structured outputs I sketched in #39. Here's a not-quite-minimal working example of using structured outputs: 

```
library(mall)

library(rjson) # For parsing structured JSON output

library(dplyr) # For efficiently wrangling parsed JSON columns
library(tidyr)
library(purrr)

# Define a JSON schema as a list to constrain a model's output
format <- list(
  type = "object",
  properties = list(
    name = list(type = "string"),
    capital = list(type = "string"),
    languages = list(type = "array",
                     items = list(type = "string")
    )
  ),
  required = list("name", "capital", "languages")
)

# Set up the model, passing `output` and `format`
llm_use('ollama', 'llama3.2', 
        output = 'structured', 
        format = format, 
        seed = 2025-03-23)

# Vectorized version can be piped directly into JSON parser
llm_vec_custom('Canada', 'tell me about the following country') |> 
  fromJSON()
# $name
# [1] "Canada"
# 
# $capital
# [1] "Ottawa"
# 
# $languages
# [1] "English"              "French"              
# [3] "indigenous languages"

# Data frame version requires more wrangling
dataf = data.frame(country = c('Canada', 'Mexico', 'United States'))

llm_custom(dataf, country, 'tell me about the following country') |>
  mutate(output = map(.pred, fromJSON)) |> 
  unnest_wider(output) |> 
  str()
# tibble [3 × 5] (S3: tbl_df/tbl/data.frame)
# $ country  : chr [1:3] "Canada" "Mexico" "United States"
# $ .pred    : chr [1:3] "{ \"name\": \"Canada\", \"capital\": \"Ottawa\", \"languages\": [\"English\",\"French\" , \"indigenous language"| __truncated__ "{\"name\": \"Mexico\", \"capital\": \"Mexico City\", \"languages\": [\"Spanish\", \"Maya\", \"Nahua\", \"Zapote"| __truncated__ "{\n\"name\": \"United States of America\",\n\"capital\": \"Washington D.C.\",\n\"languages\": [\"English\", \"S"| __truncated__
# $ name     : chr [1:3] "Canada" "Mexico" "United States of America"
# $ capital  : chr [1:3] "Ottawa" "Mexico City" "Washington D.C."
# $ languages:List of 3
# ..$ : chr [1:3] "English" "French" "indigenous languages"
# ..$ : chr [1:5] "Spanish" "Maya" "Nahua" "Zapotec" ...
# ..$ : chr [1:14] "English" "Spanish" "French" "Chinese" ...
```

Text outputs appear to be working as before. Four tests fail, three due to small differences in a code snapshot, eg, order of arguments: 

- Failure (test-llm-classify.R:38:3): Preview works
- Failure (test-llm-use.R:28:3): Stops cache
- Failure (test-llm-verify.R:36:3): Preview works

The fourth test appears to relate to the number of objects in Ollama's cache: 

- Failure (test-zzz-cache.R:3:3): Ollama cache exists and delete (`actual` is 61.0 vs. `expected` 59.0)

Since I'm not sure how these tests work, at this time I'm not going to update the snapshots or make other changes to the tests themselves. I'm also not adding a test for the structured output use case. It seems like it would be desirable to define functions `llm_structured` and `llm_structured_vec` specifically for vectored output, and then write tests for those. 